### PR TITLE
feat(profiles): add shared account-wide profile system

### DIFF
--- a/BarSmith.toc
+++ b/BarSmith.toc
@@ -2,7 +2,7 @@
 ## Title: BarSmith |cff8a5cf6Midnight|r
 ## Notes: Automatically fills action bar slots with quest items, consumables, trinkets, professions, mounts, toys, hearthstones, and class spells.
 ## Author: jrosco
-## Version: 1.0.0
+## Version: 1.1.0
 ## SavedVariables: BarSmithDB
 ## SavedVariablesPerCharacter: BarSmithCharDB
 ## OptionalDeps: Masque

--- a/Config/Defaults.lua
+++ b/Config/Defaults.lua
@@ -3,6 +3,20 @@
 -- Default configuration values and saved variable initialization
 ------------------------------------------------------------------------
 
+local DEFAULT_PROFILE_ID = "default"
+
+local function TrimString(value)
+  return (tostring(value or ""):gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function NormalizeProfileName(value, fallback)
+  local name = TrimString(value)
+  if name == "" then
+    return fallback or "Profile"
+  end
+  return name
+end
+
 BarSmith.DEFAULTS = {
   -- Global (account-wide) defaults
   global = {
@@ -10,7 +24,7 @@ BarSmith.DEFAULTS = {
     minimap = { hide = false, angle = 225 },
   },
 
-  -- Per-character defaults
+  -- Per-profile defaults
   char = {
     enabled = true,
     autoFill = true,               -- auto-fill on login / zone change
@@ -151,11 +165,470 @@ BarSmith.DEFAULTS = {
       hideDefault = false,           -- hide Blizzard micro menu when enabled
     },
   },
+
+  -- Per-character saved state
+  selection = {
+    profile = DEFAULT_PROFILE_ID,
+  },
 }
 
 ------------------------------------------------------------------------
 -- Initialize saved variables
 ------------------------------------------------------------------------
+
+function BarSmith:GetCharacterKey()
+  local name, realm = nil, nil
+  if UnitFullName then
+    name, realm = UnitFullName("player")
+  end
+  if not name and UnitName then
+    name = UnitName("player")
+  end
+  if not realm and GetRealmName then
+    realm = GetRealmName()
+  end
+  if realm and realm ~= "" then
+    return tostring(name or "Player") .. "-" .. tostring(realm)
+  end
+  return tostring(name or "Player")
+end
+
+function BarSmith:GetProfileStore()
+  if not self.db then return nil end
+  self.db.profiles = self.db.profiles or {}
+  return self.db.profiles
+end
+
+function BarSmith:GetProfileOrder()
+  if not self.db then return {} end
+  self.db.profileOrder = self.db.profileOrder or {}
+  return self.db.profileOrder
+end
+
+function BarSmith:RebuildProfileOrder()
+  local profiles = self:GetProfileStore()
+  if not profiles then return end
+
+  local order = {}
+  if profiles[DEFAULT_PROFILE_ID] then
+    table.insert(order, DEFAULT_PROFILE_ID)
+  end
+
+  local rest = {}
+  for id, profile in pairs(profiles) do
+    if id ~= DEFAULT_PROFILE_ID and type(profile) == "table" then
+      table.insert(rest, { id = id, name = profile.name or id })
+    end
+  end
+
+  table.sort(rest, function(a, b)
+    local an = string.lower(tostring(a.name or a.id))
+    local bn = string.lower(tostring(b.name or b.id))
+    if an == bn then
+      return tostring(a.id) < tostring(b.id)
+    end
+    return an < bn
+  end)
+
+  for _, entry in ipairs(rest) do
+    table.insert(order, entry.id)
+  end
+
+  self.db.profileOrder = order
+end
+
+function BarSmith:SanitizeProfileRecord(profile, fallbackName)
+  if type(profile) ~= "table" then
+    return nil
+  end
+
+  if type(profile.blacklist) == "table" and type(profile.exclude) ~= "table" then
+    profile.exclude = CopyTable(profile.blacklist)
+  end
+
+  self:MigrateDefaults(profile, self.DEFAULTS.char)
+
+  for key in pairs(profile) do
+    if type(key) == "string" and key:sub(1, 1) == "_" then
+      profile[key] = nil
+    end
+  end
+
+  profile.name = NormalizeProfileName(profile.name, fallbackName or "Profile")
+  profile.blacklist = nil
+  profile._autoHideBeforeUnlock = nil
+  return profile
+end
+
+function BarSmith:EnsureProfileRecord(profileID, source, fallbackName)
+  local profiles = self:GetProfileStore()
+  if not profiles or not profileID then return nil end
+
+  local profile = profiles[profileID]
+  if type(profile) ~= "table" then
+    profile = CopyTable(source or self.DEFAULTS.char)
+    profiles[profileID] = profile
+  end
+
+  self:SanitizeProfileRecord(profile, fallbackName or profileID)
+  return profile
+end
+
+function BarSmith:GetProfileByID(profileID)
+  local profiles = self:GetProfileStore()
+  if not profiles then return nil end
+  if not profileID or profileID == "" then
+    profileID = DEFAULT_PROFILE_ID
+  end
+  return profiles[profileID]
+end
+
+function BarSmith:GetProfileDisplayName(profileID)
+  local profile = self:GetProfileByID(profileID)
+  if profile and profile.name then
+    return profile.name
+  end
+  if profileID == DEFAULT_PROFILE_ID then
+    return "Default"
+  end
+  return tostring(profileID or "Profile")
+end
+
+function BarSmith:GetActiveProfileID()
+  if self.profileCharDB and self.profileCharDB.profile and self.profileCharDB.profile ~= "" then
+    return self.profileCharDB.profile
+  end
+  return DEFAULT_PROFILE_ID
+end
+
+function BarSmith:GetActiveProfileName()
+  return self:GetProfileDisplayName(self:GetActiveProfileID())
+end
+
+function BarSmith:FindProfileIDByName(profileName)
+  local target = string.lower(NormalizeProfileName(profileName, ""))
+  if target == "" then
+    return nil
+  end
+
+  local profiles = self:GetProfileStore()
+  if not profiles then
+    return nil
+  end
+  local order = self:GetProfileOrder()
+  for _, id in ipairs(order) do
+    local profile = profiles[id]
+    if profile and string.lower(tostring(profile.name or "")) == target then
+      return id
+    end
+  end
+
+  for id, profile in pairs(profiles) do
+    if profile and string.lower(tostring(profile.name or "")) == target then
+      return id
+    end
+  end
+
+  return nil
+end
+
+function BarSmith:ResolveProfileID(value)
+  local text = NormalizeProfileName(value, "")
+  if text == "" then
+    return self:GetActiveProfileID()
+  end
+
+  local profiles = self:GetProfileStore()
+  if not profiles then
+    return nil
+  end
+  if profiles[text] then
+    return text
+  end
+
+  local byName = self:FindProfileIDByName(text)
+  if byName then
+    return byName
+  end
+
+  return nil
+end
+
+function BarSmith:IsProfileNameAvailable(profileName, ignoreID)
+  local target = string.lower(NormalizeProfileName(profileName, ""))
+  if target == "" then
+    return false
+  end
+
+  local profiles = self:GetProfileStore()
+  if not profiles then
+    return true
+  end
+  for id, profile in pairs(profiles or {}) do
+    if id ~= ignoreID and profile and string.lower(tostring(profile.name or "")) == target then
+      return false
+    end
+  end
+  return true
+end
+
+function BarSmith:GenerateProfileID()
+  local profiles = self:GetProfileStore()
+  if not profiles then
+    return DEFAULT_PROFILE_ID
+  end
+
+  local nextID = tonumber(self.db.profileNextID) or 1
+  local profileID = nil
+  repeat
+    profileID = "profile" .. tostring(nextID)
+    nextID = nextID + 1
+  until not profiles[profileID]
+
+  self.db.profileNextID = nextID
+  return profileID
+end
+
+function BarSmith:CreateProfile(profileName, source)
+  local profiles = self:GetProfileStore()
+  if not profiles then return nil end
+
+  local profileID = self:GenerateProfileID()
+  local sourceTable = self:GetProfileByID(source)
+  if type(source) == "table" then
+    sourceTable = source
+  end
+
+  local profile = CopyTable(sourceTable or self.DEFAULTS.char)
+  local baseName = NormalizeProfileName(profileName, "Profile")
+  local uniqueName = baseName
+  local suffix = 2
+  while not self:IsProfileNameAvailable(uniqueName) do
+    uniqueName = baseName .. " (" .. tostring(suffix) .. ")"
+    suffix = suffix + 1
+  end
+  profile.name = uniqueName
+  profile.created = time and time() or nil
+  profile.updated = time and time() or nil
+  profile.blacklist = nil
+  profile._autoHideBeforeUnlock = nil
+  self:SanitizeProfileRecord(profile, profile.name)
+  profiles[profileID] = profile
+  self:RebuildProfileOrder()
+  return profileID, profile
+end
+
+function BarSmith:CloneProfile(sourceProfileID, newProfileName)
+  local source = self:GetProfileByID(sourceProfileID)
+  if not source then
+    source = self:GetProfileByID(DEFAULT_PROFILE_ID) or self.DEFAULTS.char
+  end
+  return self:CreateProfile(newProfileName, source)
+end
+
+function BarSmith:RenameProfile(profileID, newProfileName)
+  local profiles = self:GetProfileStore()
+  if not profiles or not profileID or profileID == DEFAULT_PROFILE_ID then
+    return false, "Default cannot be renamed."
+  end
+
+  local profile = profiles[profileID]
+  if not profile then
+    return false, "Profile not found."
+  end
+
+  local name = NormalizeProfileName(newProfileName, "")
+  if name == "" then
+    return false, "Profile name cannot be blank."
+  end
+  if not self:IsProfileNameAvailable(name, profileID) then
+    return false, "A profile with that name already exists."
+  end
+
+  profile.name = name
+  profile.updated = time and time() or nil
+  self:SanitizeProfileRecord(profile, name)
+  self:RebuildProfileOrder()
+  return true
+end
+
+function BarSmith:DeleteProfile(profileID)
+  local profiles = self:GetProfileStore()
+  if not profiles or not profileID or profileID == DEFAULT_PROFILE_ID then
+    return false, "Default cannot be deleted."
+  end
+  if not profiles[profileID] then
+    return false, "Profile not found."
+  end
+
+  profiles[profileID] = nil
+  self:RebuildProfileOrder()
+
+  if self.profileCharDB and self.profileCharDB.profile == profileID then
+    self:SetActiveProfile(DEFAULT_PROFILE_ID, true)
+  end
+
+  return true
+end
+
+function BarSmith:SetActiveProfile(profileID, silent)
+  local requestedID = NormalizeProfileName(profileID, "")
+  local resolvedID = nil
+  if requestedID == "" then
+    resolvedID = DEFAULT_PROFILE_ID
+  else
+    resolvedID = self:ResolveProfileID(requestedID)
+    if not resolvedID then
+      return false, "Profile not found."
+    end
+  end
+  local profiles = self:GetProfileStore()
+  if not profiles then
+    return false, "Profile store unavailable."
+  end
+
+  local profile = self:EnsureProfileRecord(resolvedID, self.DEFAULTS.char, resolvedID == DEFAULT_PROFILE_ID and "Default" or resolvedID)
+  if not profile then
+    return false, "Unable to load profile."
+  end
+
+  self.profileCharDB = self.profileCharDB or {}
+  self.profileCharDB.profile = resolvedID
+  BarSmithCharDB = self.profileCharDB
+
+  self.chardb = profile
+  self.activeProfileID = resolvedID
+
+  local barFrame = self:GetModule("BarFrame")
+  if barFrame then
+    barFrame._autoHideBeforeUnlock = nil
+  end
+
+  if self.SyncFiltersFromSettings then
+    self:SyncFiltersFromSettings()
+  end
+  if self.RefreshSettingsProxy then
+    self:RefreshSettingsProxy()
+  end
+
+  local quickBar = self:GetModule("QuickBar")
+  if quickBar and quickBar.Refresh then
+    quickBar:Refresh()
+  end
+
+  if not silent then
+    self:Print("Active profile: " .. self:GetActiveProfileName())
+    self:FireCallback("SETTINGS_CHANGED")
+  end
+
+  return true
+end
+
+function BarSmith:GetProfileList()
+  local profiles = self:GetProfileStore()
+  if not profiles then
+    return {}
+  end
+  local order = self:GetProfileOrder()
+  local activeID = self:GetActiveProfileID()
+  local list = {}
+
+  for _, id in ipairs(order) do
+    local profile = profiles[id]
+    if profile then
+      table.insert(list, {
+        id = id,
+        name = profile.name or id,
+        active = (id == activeID),
+      })
+    end
+  end
+
+  return list
+end
+
+function BarSmith:EnsureProfileStore()
+  if not self.db then return end
+
+  self.db.profiles = self.db.profiles or {}
+  self.db.profileNextID = tonumber(self.db.profileNextID) or 1
+
+  local profiles = self.db.profiles
+  local defaultProfile = profiles[DEFAULT_PROFILE_ID]
+  if type(defaultProfile) ~= "table" then
+    defaultProfile = CopyTable(self.DEFAULTS.char)
+    profiles[DEFAULT_PROFILE_ID] = defaultProfile
+  end
+  self:SanitizeProfileRecord(defaultProfile, "Default")
+  defaultProfile.name = "Default"
+
+  for id, profile in pairs(profiles) do
+    if type(profile) == "table" then
+      self:SanitizeProfileRecord(profile, id == DEFAULT_PROFILE_ID and "Default" or id)
+    else
+      profiles[id] = CopyTable(self.DEFAULTS.char)
+      self:SanitizeProfileRecord(profiles[id], id == DEFAULT_PROFILE_ID and "Default" or id)
+    end
+  end
+
+  self:RebuildProfileOrder()
+end
+
+function BarSmith:NormalizeLegacyCharacterDB(source)
+  local legacy = {}
+  local sourceTable = type(source) == "table" and source or {}
+  for k, v in pairs(sourceTable) do
+    if k ~= "profile" and k ~= "profileVersion" and not (type(k) == "string" and k:sub(1, 1) == "_") then
+      legacy[k] = v
+    end
+  end
+
+  if type(legacy.blacklist) == "table" and type(legacy.exclude) ~= "table" then
+    legacy.exclude = CopyTable(legacy.blacklist)
+  end
+
+  return legacy
+end
+
+function BarSmith:MigrateLegacyCharacterProfile()
+  self.profileCharDB = BarSmithCharDB or {}
+  BarSmithCharDB = self.profileCharDB
+
+  local selectedProfileID = self.profileCharDB.profile
+  if selectedProfileID and self:GetProfileByID(selectedProfileID) then
+    self.profileCharDB = {
+      profile = selectedProfileID,
+    }
+    BarSmithCharDB = self.profileCharDB
+    self:SetActiveProfile(selectedProfileID, true)
+    return
+  end
+
+  local legacy = self:NormalizeLegacyCharacterDB(self.profileCharDB)
+  local hasLegacyData = next(legacy) ~= nil
+  local profileID = DEFAULT_PROFILE_ID
+
+  if hasLegacyData then
+    local profileName = self:GetCharacterKey()
+    profileID = self:GenerateProfileID()
+    local profile = CopyTable(self.DEFAULTS.char)
+    for k, v in pairs(legacy) do
+      profile[k] = v
+    end
+    profile.name = profileName
+    profile.blacklist = nil
+    profile._autoHideBeforeUnlock = nil
+    self:SanitizeProfileRecord(profile, profileName)
+    self.db.profiles[profileID] = profile
+    self:RebuildProfileOrder()
+  end
+
+  self.profileCharDB = {
+    profile = profileID,
+  }
+  BarSmithCharDB = self.profileCharDB
+  self:SetActiveProfile(profileID, true)
+end
 
 function BarSmith:InitDB()
   -- Account-wide
@@ -164,17 +637,12 @@ function BarSmith:InitDB()
   end
   self.db = BarSmithDB
 
-  -- Per-character
-  if not BarSmithCharDB then
-    BarSmithCharDB = CopyTable(self.DEFAULTS.char)
-  end
-  self.chardb = BarSmithCharDB
+  self:EnsureProfileStore()
 
   -- Migration: fill in any missing keys from defaults
   self:MigrateDefaults(self.db, self.DEFAULTS.global)
-  self:MigrateDefaults(self.chardb, self.DEFAULTS.char)
+  self:MigrateLegacyCharacterProfile()
 
-  -- Sanity: recover from corrupted or legacy saved variables.
   if type(self.chardb.modules) ~= "table" then
     self.chardb.modules = CopyTable(self.DEFAULTS.char.modules)
   end
@@ -248,11 +716,35 @@ end
 ------------------------------------------------------------------------
 
 function BarSmith:ResetCharacterSettings()
-  BarSmithCharDB = CopyTable(self.DEFAULTS.char)
-  self.chardb = BarSmithCharDB
-  self:Print("Character settings reset to defaults.")
+  local activeID = self:GetActiveProfileID()
+  local profile = self:EnsureProfileRecord(activeID, self.DEFAULTS.char, activeID == DEFAULT_PROFILE_ID and "Default" or activeID)
+  if not profile then return end
+
+  local profileName = profile.name or self:GetProfileDisplayName(activeID)
+  local created = profile.created
+  local resetProfile = CopyTable(self.DEFAULTS.char)
+  resetProfile.name = profileName
+  resetProfile.created = created
+  resetProfile.updated = time and time() or nil
+  if activeID == DEFAULT_PROFILE_ID then
+    resetProfile.name = "Default"
+  end
+  self.db.profiles[activeID] = resetProfile
+  self.chardb = resetProfile
+  local barFrame = self:GetModule("BarFrame")
+  if barFrame then
+    barFrame._autoHideBeforeUnlock = nil
+  end
+  if self.SyncFiltersFromSettings then
+    self:SyncFiltersFromSettings()
+  end
+  self:Print("Profile reset to defaults: " .. resetProfile.name)
   if self.RefreshSettingsProxy then
     self:RefreshSettingsProxy()
+  end
+  local quickBar = self:GetModule("QuickBar")
+  if quickBar and quickBar.Refresh then
+    quickBar:Refresh()
   end
   self:FireCallback("SETTINGS_CHANGED")
 end
@@ -271,31 +763,52 @@ function BarSmith:ResetCharacterSettingsKeepLists()
   local keepMacroSlots = chardb.macros and chardb.macros.slots
     and CopyTable(chardb.macros.slots) or nil
 
-  BarSmithCharDB = CopyTable(self.DEFAULTS.char)
-  self.chardb = BarSmithCharDB
+  local activeID = self:GetActiveProfileID()
+  local profile = self:EnsureProfileRecord(activeID, self.DEFAULTS.char, activeID == DEFAULT_PROFILE_ID and "Default" or activeID)
+  if not profile then return end
 
+  local profileName = profile.name or self:GetProfileDisplayName(activeID)
+  local created = profile.created
+  local resetProfile = CopyTable(self.DEFAULTS.char)
+  resetProfile.name = profileName
+  resetProfile.created = created
+  resetProfile.updated = time and time() or nil
   if keepExclude then
-    self.chardb.exclude = keepExclude
+    resetProfile.exclude = keepExclude
   end
   if keepConsumableInclude then
-    self.chardb.consumables.include = keepConsumableInclude
+    resetProfile.consumables.include = keepConsumableInclude
   end
   if keepMountInclude then
-    self.chardb.mounts.include = keepMountInclude
+    resetProfile.mounts.include = keepMountInclude
   end
   if keepToyInclude then
-    self.chardb.toys.include = keepToyInclude
+    resetProfile.toys.include = keepToyInclude
   end
   if keepClassSpells then
-    self.chardb.classSpells.customSpellIDs = keepClassSpells
+    resetProfile.classSpells.customSpellIDs = keepClassSpells
   end
   if keepMacroSlots then
-    self.chardb.macros.slots = keepMacroSlots
+    resetProfile.macros.slots = keepMacroSlots
   end
 
-  self:Print("Settings reset (includes/excludes preserved).")
+  self.db.profiles[activeID] = resetProfile
+  self.chardb = resetProfile
+  local barFrame = self:GetModule("BarFrame")
+  if barFrame then
+    barFrame._autoHideBeforeUnlock = nil
+  end
+  if self.SyncFiltersFromSettings then
+    self:SyncFiltersFromSettings()
+  end
+
+  self:Print("Profile reset (includes/excludes preserved): " .. resetProfile.name)
   if self.RefreshSettingsProxy then
     self:RefreshSettingsProxy()
+  end
+  local quickBar = self:GetModule("QuickBar")
+  if quickBar and quickBar.Refresh then
+    quickBar:Refresh()
   end
   self:FireCallback("SETTINGS_CHANGED")
 end

--- a/Config/Settings.lua
+++ b/Config/Settings.lua
@@ -102,6 +102,8 @@ function BarSmith:RefreshSettingsProxy()
   settingsProxy["BarSmith_Mounts_TopFavs"]    = BarSmith.chardb.mounts.topFavorites
   settingsProxy["BarSmith_Mounts_AllFavs"]    = BarSmith.chardb.mounts.allFavorites
   settingsProxy["BarSmith_Debug"]             = BarSmith.db and BarSmith.db.debug
+  settingsProxy["BarSmith_Profile"]           = BarSmith:GetActiveProfileID()
+  settingsProxy["BarSmith_Profile_Name"]      = BarSmith:GetActiveProfileName()
   settingsProxy["BarSmith_MicroMenu_HideDefault"] = BarSmith.chardb.microMenu
     and BarSmith.chardb.microMenu.hideDefault == true
   settingsProxy["BarSmith_Con_Potions"]       = BarSmith.chardb.consumables.potions
@@ -181,6 +183,54 @@ local function FormatFloat2(value)
   return string.format("%.2f", tonumber(value) or 0)
 end
 
+local function BuildProfileDropdownOptions()
+  local container = Settings.CreateControlTextContainer()
+  for _, entry in ipairs(BarSmith:GetProfileList()) do
+    local label = entry.name
+    if entry.active then
+      label = label .. " (Active)"
+    end
+    container:Add(entry.id, label)
+  end
+  return container:GetData()
+end
+
+local function ShowProfileNamePopup(popupName, title, defaultText, onAccept)
+  StaticPopupDialogs[popupName] = {
+    text = title,
+    button1 = "OK",
+    button2 = "Cancel",
+    hasEditBox = true,
+    editBoxWidth = 240,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+    OnShow = function(self)
+      local editBox = self.editBox or self.EditBox
+      if not editBox then return end
+      editBox:SetText(defaultText or "")
+      editBox:HighlightText()
+      editBox:SetFocus()
+    end,
+    OnHide = function(self)
+      local editBox = self.editBox or self.EditBox
+      if editBox then
+        editBox:ClearFocus()
+      end
+    end,
+    OnAccept = function(self)
+      local editBox = self.editBox or self.EditBox
+      if not editBox then return end
+      local value = strtrim(editBox:GetText() or "")
+      if value ~= "" and onAccept then
+        onAccept(value)
+      end
+    end,
+  }
+  StaticPopup_Show(popupName)
+end
+
 ------------------------------------------------------------------------
 -- Build Settings Panel
 ------------------------------------------------------------------------
@@ -192,6 +242,7 @@ function mod:Init()
   end
   local category, layout                      = Settings.RegisterVerticalLayoutCategory(title)
   BarSmith.settingsCategoryID                 = category:GetID()
+  local profilesCategory, profilesLayout       = Settings.RegisterVerticalLayoutSubcategory(category, "Profiles")
   local quickBarCategory, quickBarLayout      = Settings.RegisterVerticalLayoutSubcategory(category, "QuickBar")
   local modulesCategory, modulesLayout        = Settings.RegisterVerticalLayoutSubcategory(category, "Modules")
   local filtersCategory, filtersLayout        = Settings.RegisterVerticalLayoutSubcategory(category, "Filters")
@@ -205,6 +256,148 @@ function mod:Init()
 
   -- Seed proxy with current values
   BarSmith:RefreshSettingsProxy()
+
+  ---------- Profiles ----------
+  profilesLayout:AddInitializer(CreateSettingsListSectionHeaderInitializer("Profiles"))
+  do
+    local initializer = Settings.CreateElementInitializer("BarSmithSettingsNoteTemplate", {
+      text = "Shared profiles are account-wide. Each character selects one active profile, and Default is always available.",
+    })
+    profilesLayout:AddInitializer(initializer)
+  end
+
+  do
+    local variable = "BarSmith_Profile"
+    local name = "Active Profile"
+    local tooltip = "Choose which shared profile this character uses."
+    local defaultValue = "default"
+    local setting = Settings.RegisterProxySetting(profilesCategory, variable, "string", name, defaultValue,
+      function()
+        return BarSmith:GetActiveProfileID()
+      end,
+      function(value)
+        BarSmith:SetActiveProfile(value)
+      end)
+    Settings.CreateDropdown(profilesCategory, setting, BuildProfileDropdownOptions, tooltip)
+  end
+
+  do
+    local initializer = Settings.CreateElementInitializer("BarSmithSettingsButtonTemplate", {
+      text = "Create a new shared profile from the built-in defaults.",
+      buttonText = "New Profile",
+      OnClick = function()
+        ShowProfileNamePopup("BARSMITH_CREATE_PROFILE", "Create a new profile", "New Profile", function(name)
+          local id = BarSmith:CreateProfile(name, BarSmith.DEFAULTS and BarSmith.DEFAULTS.char or nil)
+          if id then
+            BarSmith:SetActiveProfile(id, true)
+            BarSmith:FireCallback("SETTINGS_CHANGED")
+            BarSmith:Print("Created profile: " .. BarSmith:GetActiveProfileName())
+          end
+        end)
+      end,
+    })
+    profilesLayout:AddInitializer(initializer)
+  end
+
+  do
+    local initializer = Settings.CreateElementInitializer("BarSmithSettingsButtonTemplate", {
+      text = "Clone the active profile into a new shared profile.",
+      buttonText = "Clone Profile",
+      OnClick = function()
+        local defaultText = BarSmith:GetActiveProfileName() .. " Copy"
+        ShowProfileNamePopup("BARSMITH_CLONE_PROFILE", "Clone the active profile", defaultText, function(name)
+          local id = BarSmith:CloneProfile(BarSmith:GetActiveProfileID(), name)
+          if id then
+            BarSmith:SetActiveProfile(id, true)
+            BarSmith:FireCallback("SETTINGS_CHANGED")
+            BarSmith:Print("Cloned profile to: " .. BarSmith:GetActiveProfileName())
+          end
+        end)
+      end,
+    })
+    profilesLayout:AddInitializer(initializer)
+  end
+
+  do
+    local initializer = Settings.CreateElementInitializer("BarSmithSettingsButtonTemplate", {
+      text = "Rename the active profile.",
+      buttonText = "Rename Profile",
+      OnClick = function()
+        local currentName = BarSmith:GetActiveProfileName()
+        local activeID = BarSmith:GetActiveProfileID()
+        ShowProfileNamePopup("BARSMITH_RENAME_PROFILE", "Rename the active profile", currentName, function(name)
+          local ok, err = BarSmith:RenameProfile(activeID, name)
+          if ok then
+            BarSmith:RefreshSettingsProxy()
+            BarSmith:FireCallback("SETTINGS_CHANGED")
+            BarSmith:Print("Renamed profile to: " .. BarSmith:GetActiveProfileName())
+          elseif err then
+            BarSmith:Print(err)
+          end
+        end)
+      end,
+    })
+    profilesLayout:AddInitializer(initializer)
+  end
+
+  do
+    local initializer = Settings.CreateElementInitializer("BarSmithSettingsButtonTemplate", {
+      text = "Delete the active profile. Default cannot be removed.",
+      buttonText = "Delete Profile",
+      OnClick = function()
+        local activeID = BarSmith:GetActiveProfileID()
+        local activeName = BarSmith:GetActiveProfileName()
+        if activeID == "default" then
+          BarSmith:Print("Default cannot be deleted.")
+          return
+        end
+        local dialog = StaticPopupDialogs["BARSMITH_DELETE_PROFILE"] or {}
+        StaticPopupDialogs["BARSMITH_DELETE_PROFILE"] = dialog
+        dialog.text = "Delete the active profile? This cannot be undone."
+        dialog.button1 = "Delete"
+        dialog.button2 = "Cancel"
+        dialog.timeout = 0
+        dialog.whileDead = true
+        dialog.hideOnEscape = true
+        dialog.preferredIndex = 3
+        dialog.OnAccept = function()
+          local ok, err = BarSmith:DeleteProfile(activeID)
+          if ok then
+            BarSmith:RefreshSettingsProxy()
+            BarSmith:FireCallback("SETTINGS_CHANGED")
+            BarSmith:Print("Deleted profile: " .. activeName)
+          elseif err then
+            BarSmith:Print(err)
+          end
+        end
+        StaticPopup_Show("BARSMITH_DELETE_PROFILE")
+      end,
+    })
+    profilesLayout:AddInitializer(initializer)
+  end
+
+  do
+    local initializer = Settings.CreateElementInitializer("BarSmithSettingsButtonTemplate", {
+      text = "Reset the active profile back to the built-in defaults.",
+      buttonText = "Reset Profile",
+      OnClick = function()
+        StaticPopupDialogs["BARSMITH_RESET_PROFILE"] = StaticPopupDialogs["BARSMITH_RESET_PROFILE"] or {
+          text = "Reset the active profile to defaults?",
+          button1 = "Reset",
+          button2 = "Cancel",
+          timeout = 0,
+          whileDead = true,
+          hideOnEscape = true,
+          preferredIndex = 3,
+          OnAccept = function()
+            BarSmith:ResetCharacterSettings()
+          end,
+        }
+        StaticPopup_Show("BARSMITH_RESET_PROFILE")
+      end,
+    })
+    profilesLayout:AddInitializer(initializer)
+  end
 
   ---------- General ----------
   layout:AddInitializer(CreateSettingsListSectionHeaderInitializer("General"))

--- a/Init.lua
+++ b/Init.lua
@@ -11,11 +11,14 @@ SLASH_BARSMITH1 = "/barsmith"
 SLASH_BARSMITH2 = "/bs"
 
 SlashCmdList["BARSMITH"] = function(msg)
-  msg = strtrim(msg or ""):lower()
+  msg = strtrim(msg or "")
+  local command, rest = msg:match("^(%S+)%s*(.*)$")
+  command = string.lower(command or "")
+  rest = strtrim(rest or "")
 
-  if msg == "fill" or msg == "run" then
+  if command == "fill" or command == "run" then
     BarSmith:RunAutoFill()
-  elseif msg == "clear" then
+  elseif command == "clear" then
     if not InCombatLockdown() then
       local barFrame = BarSmith:GetModule("BarFrame")
       if barFrame then
@@ -26,26 +29,25 @@ SlashCmdList["BARSMITH"] = function(msg)
     else
       BarSmith:Print("Cannot clear bar during combat.")
     end
-  elseif msg == "lock" then
+  elseif command == "lock" then
     local barFrame = BarSmith:GetModule("BarFrame")
     if barFrame then
       barFrame:SetLocked(not BarSmith.chardb.barLocked)
     end
-  elseif msg == "show" then
+  elseif command == "show" then
     local barFrame = BarSmith:GetModule("BarFrame")
     if barFrame then barFrame:Show() end
-  elseif msg == "hide" then
+  elseif command == "hide" then
     local barFrame = BarSmith:GetModule("BarFrame")
     if barFrame then barFrame:Hide() end
-  elseif msg == "config" or msg == "options" or msg == "settings" then
+  elseif command == "config" or command == "options" or command == "settings" then
     BarSmith:OpenSettings()
-  elseif msg == "reset" then
+  elseif command == "reset" then
     BarSmith:ResetCharacterSettings()
-  elseif msg == "debug" then
+  elseif command == "debug" then
     BarSmith.db.debug = not BarSmith.db.debug
     BarSmith:Print("Debug mode: " .. (BarSmith.db.debug and "|cff00ff00ON|r" or "|cffff0000OFF|r"))
-  elseif msg == "exclude" or msg == "exclude list" or msg == "ex" or msg == "ex list"
-      or msg == "blacklist" or msg == "blacklist list" or msg == "bl" or msg == "bl list" then
+  elseif command == "exclude" or command == "ex" or command == "blacklist" then
     local exclude = BarSmith.chardb.exclude or BarSmith.chardb.blacklist or {}
     local count = 0
     BarSmith:Print("Excluded items:")
@@ -56,18 +58,18 @@ SlashCmdList["BARSMITH"] = function(msg)
     if count == 0 then
       BarSmith:Print("  (none)")
     end
-  elseif msg == "clearexclude" or msg == "exclude clear" or msg == "ex clear"
-      or msg == "clearblacklist" or msg == "blacklist clear" or msg == "bl clear" then
+  elseif command == "clearexclude" or command == "exclear" or command == "clearblacklist"
+      or (command == "ex" and rest == "clear") or (command == "blacklist" and rest == "clear") then
     BarSmith.chardb.exclude = {}
     BarSmith.chardb.blacklist = nil
     BarSmith:Print("Exclude list cleared.")
     BarSmith:RunAutoFill(true)
-  elseif msg == "clearinclude" or msg == "include clear"
-      or msg == "clearextras" or msg == "extras clear" then
+  elseif command == "clearinclude" or command == "clearextras" or (command == "include" and rest == "clear")
+      or (command == "extras" and rest == "clear") then
     BarSmith:ClearInclude()
     BarSmith:Print("Include list cleared.")
     BarSmith:RunAutoFill(true)
-  elseif msg == "status" then
+  elseif command == "status" then
     BarSmith:PrintStatus()
   else
     BarSmith:Print("Commands:")
@@ -77,9 +79,9 @@ SlashCmdList["BARSMITH"] = function(msg)
     BarSmith:Print("  |cff00ccff/bs show|r / |cff00ccff/bs hide|r — Show or hide the bar")
     BarSmith:Print("  |cff00ccff/bs config|r — Open settings panel")
     BarSmith:Print("  |cff00ccff/bs status|r — Show current module status")
-    BarSmith:Print("  |cff00ccff/bs reset|r — Reset character settings")
+    BarSmith:Print("  |cff00ccff/bs reset|r — Reset the active profile")
     BarSmith:Print("  |cff00ccff/bs exclude|r / |cff00ccff/bs ex|r — Show excluded items")
-    BarSmith:Print("  |cff00ccff/bs clearexclude|r / |cff00ccff/bs ex clear|r — Clear excluded items")
+    BarSmith:Print("  |cff00ccff/bs clearexclude|r / |cff00ccff/bs exclear|r / |cff00ccff/bs ex clear|r — Clear excluded items")
     BarSmith:Print("  |cff00ccff/bs clearinclude|r — Clear included items/spells")
     BarSmith:Print("  |cff00ccff/bs debug|r — Toggle debug output")
   end
@@ -118,6 +120,12 @@ end
 
 function BarSmith:PrintStatus()
   self:Print("--- BarSmith Status ---")
+  local activeProfileID = self:GetActiveProfileID()
+  local profileLabel = self:GetActiveProfileName()
+  if activeProfileID == "default" then
+    profileLabel = profileLabel .. " (Default)"
+  end
+  self:Print("Profile: " .. profileLabel)
   self:Print("Enabled: " .. (self.chardb.enabled and "|cff00ff00Yes|r" or "|cffff0000No|r"))
   self:Print("Auto-fill: " .. (self.chardb.autoFill and "|cff00ff00On|r" or "|cffff0000Off|r"))
   self:Print("Bar locked: " .. (self.chardb.barLocked and "Yes" or "No"))

--- a/Modules/BarFrame.lua
+++ b/Modules/BarFrame.lua
@@ -569,13 +569,13 @@ end
 function BarFrame:SetLocked(locked)
   if not BarSmith.chardb then return end
   if not locked then
-    if BarSmith.chardb._autoHideBeforeUnlock == nil then
-      BarSmith.chardb._autoHideBeforeUnlock = BarSmith.chardb.barAutoHideMouseover
+    if self._autoHideBeforeUnlock == nil then
+      self._autoHideBeforeUnlock = BarSmith.chardb.barAutoHideMouseover
     end
     BarSmith.chardb.barAutoHideMouseover = false
-  elseif BarSmith.chardb._autoHideBeforeUnlock ~= nil then
-    BarSmith.chardb.barAutoHideMouseover = BarSmith.chardb._autoHideBeforeUnlock
-    BarSmith.chardb._autoHideBeforeUnlock = nil
+  elseif self._autoHideBeforeUnlock ~= nil then
+    BarSmith.chardb.barAutoHideMouseover = self._autoHideBeforeUnlock
+    self._autoHideBeforeUnlock = nil
   end
   BarSmith.chardb.barLocked = locked
   if BarSmith.UpdateSettingsProxy then

--- a/Modules/QuickBar.lua
+++ b/Modules/QuickBar.lua
@@ -667,6 +667,21 @@ function QuickBar:Refresh()
   local cfg = self:GetConfig()
   cfg.slots = cfg.slots or {}
   local inCombat = InCombatLockdown()
+  if inCombat then
+    self._pendingRefresh = true
+    if not self._regenFrame then
+      local frame = CreateFrame("Frame")
+      frame:RegisterEvent("PLAYER_REGEN_ENABLED")
+      frame:SetScript("OnEvent", function()
+        if QuickBar._pendingRefresh then
+          QuickBar._pendingRefresh = nil
+          QuickBar:Refresh()
+        end
+      end)
+      self._regenFrame = frame
+    end
+    return
+  end
   if self.previewMode and not inCombat then
     self:UpdateLayout(self:GetPreviewCount())
     self:UpdateBackdropVisibility()

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,16 +4,21 @@ Use this checklist after changes to `BarFrame` or related modules.
 
 1. Reload UI and confirm addon loads without errors (`/reload`).
 2. Run `/bs` and confirm the help text prints.
-3. Verify the bar appears and auto-fills on login (wait a few seconds after reload).
-4. Toggle lock state with `/bs lock` and confirm the drag anchor shows only when unlocked.
-5. Drag the bar and `/reload`, then confirm the position persists.
-6. If auto-hide on mouseover is enabled, confirm the bar fades and restores on hover.
-7. Hover buttons and confirm tooltips show correctly with the configured tooltip modifier.
-8. Click a parent button with a flyout and confirm children show and auto-close.
-9. Click a flyout child and confirm it promotes to primary.
-10. Open keybinds and confirm module bindings trigger the correct buttons.
-11. Drag a consumable, toy, mount, or spell to the bar and confirm it is included.
-12. Shift + Right Click on a button opens the settings menu.
-13. Ctrl + Shift + Right Click removes or excludes as before.
-14. Alt + Left Click on a flyout child adds it to QuickBar.
-15. Cooldowns animate and range coloring updates in combat and out of combat.
+3. Run `/bs status` and confirm the active profile name is shown.
+4. Verify the bar appears and auto-fills on login (wait a few seconds after reload).
+5. Create a new profile from the settings panel, then switch to it and confirm it becomes active.
+6. Clone the active profile, rename it, and confirm the new name persists after `/reload`.
+7. Switch between two profiles and confirm the bar, QuickBar, and module toggles update correctly.
+8. Toggle lock state with `/bs lock` and confirm the drag anchor shows only when unlocked.
+9. Drag the bar and `/reload`, then confirm the position persists.
+10. If auto-hide on mouseover is enabled, confirm the bar fades and restores on hover.
+11. Hover buttons and confirm tooltips show correctly with the configured tooltip modifier.
+12. Click a parent button with a flyout and confirm children show and auto-close.
+13. Click a flyout child and confirm it promotes to primary.
+14. Open keybinds and confirm module bindings trigger the correct buttons.
+15. Drag a consumable, toy, mount, or spell to the bar and confirm it is included.
+16. Shift + Right Click on a button opens the settings menu.
+17. Ctrl + Shift + Right Click removes or excludes as before.
+18. Alt + Left Click on a flyout child adds it to QuickBar.
+19. Confirm profile delete/reset actions behave correctly and the Default profile cannot be removed.
+20. Cooldowns animate and range coloring updates in combat and out of combat.


### PR DESCRIPTION
- add built-in Default profile and per-character active profile selection

- store named profiles in BarSmithDB and keep only the selected profile in BarSmithCharDB

- migrate legacy character settings into profiles safely

- add profile management to the Blizzard settings panel

- keep QuickBar and bar state updates combat-safe and profile-aware

- update status output and testing notes for profile workflows